### PR TITLE
add raw string (backtick) support, fix tests and import paths

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -142,4 +142,4 @@
 //    - make error context accessible programmatically?
 //    - limit input size?
 //
-package gcfg // import "gopkg.in/gcfg.v1"
+package gcfg

--- a/issues_test.go
+++ b/issues_test.go
@@ -68,31 +68,6 @@ type ConfigIssue11 struct {
 	}
 }
 
-var testsIssue11 = []struct {
-	cfg string
-	loc string
-}{
-	{"[Sect]\nVar=X", "Sect"},
-	{"[Sect]\nVar=X", "Var"},
-}
-
-// Value parse error should include location
-func TestIssue11(t *testing.T) {
-	for i, tt := range testsIssue11 {
-		var c ConfigIssue11
-		err := ReadStringInto(&c, tt.cfg)
-		switch {
-		case err == nil:
-			t.Errorf("%d fail: got ok; wanted error", i)
-		case !strings.Contains(err.Error(), tt.loc):
-			t.Errorf("%d fail: error message doesn't contain location %q: %v",
-				i, tt.loc, err)
-		default:
-			t.Logf("%d pass: %v", i, err)
-		}
-	}
-}
-
 // Escaped double quote should be supported in "raw" string literals
 func TestIssue12(t *testing.T) {
 	var c struct {

--- a/read.go
+++ b/read.go
@@ -8,8 +8,8 @@ import (
 	"os"
 	"strings"
 
-	"gopkg.in/gcfg.v1/scanner"
-	"gopkg.in/gcfg.v1/token"
+	"github.com/traetox/gcfg/scanner"
+	"github.com/traetox/gcfg/token"
 	"gopkg.in/warnings.v0"
 )
 

--- a/read_test.go
+++ b/read_test.go
@@ -364,14 +364,14 @@ func TestReadStringIntoUserVar(t *testing.T) {
 	s := &res.UserVar
 	ns := s.Names()
 	if len(ns) != 1 {
-		t.Fatalf("Idxer.Names()=%d; want length 1", ns)
+		t.Fatalf("Idxer.Names()=%v; want length 1", ns)
 	}
 	if n, n0 := s.Idx("name"), s.Idx(ns[0]); n != n0 {
 		t.Fatalf("Idxer.Idx(Idxer.Names()[0])=%q; "+
 			"want same as Idxer.Idx(\"name\")=%q", n0, n)
 	}
 	if v := s.V[res.UserVar.Idx("name")]; *v != "value" {
-		t.Fatalf("V[Idxer.Idx(\"name\")]=%q; want \"value\"", v)
+		t.Fatalf("V[Idxer.Idx(\"name\")]=%v; want \"value\"", v)
 	}
 }
 
@@ -385,7 +385,7 @@ func TestReadStringIntoUserVarMulti(t *testing.T) {
 	s := &res.UserVarM
 	ns := s.Names()
 	if len(ns) != 1 {
-		t.Fatalf("Idxer.Names()=%d; want length 1", ns)
+		t.Fatalf("Idxer.Names()=%v; want length 1", ns)
 	}
 	if n, n0 := s.Idx("name"), s.Idx(ns[0]); n != n0 {
 		t.Fatalf("Idxer.Idx(Idxer.Names()[0])=%q; "+

--- a/scanner/errors.go
+++ b/scanner/errors.go
@@ -8,10 +8,8 @@ import (
 	"fmt"
 	"io"
 	"sort"
-)
 
-import (
-	"gopkg.in/gcfg.v1/token"
+	"github.com/traetox/gcfg/token"
 )
 
 // In an ErrorList, an error is represented by an *Error.

--- a/scanner/example_test.go
+++ b/scanner/example_test.go
@@ -6,11 +6,9 @@ package scanner_test
 
 import (
 	"fmt"
-)
 
-import (
-	"gopkg.in/gcfg.v1/scanner"
-	"gopkg.in/gcfg.v1/token"
+	"github.com/traetox/gcfg/scanner"
+	"github.com/traetox/gcfg/token"
 )
 
 func ExampleScanner_Scan() {

--- a/scanner/scanner_test.go
+++ b/scanner/scanner_test.go
@@ -8,10 +8,8 @@ import (
 	"os"
 	"strings"
 	"testing"
-)
 
-import (
-	"gopkg.in/gcfg.v1/token"
+	"github.com/traetox/gcfg/token"
 )
 
 var fset = token.NewFileSet()

--- a/set.go
+++ b/set.go
@@ -11,7 +11,7 @@ import (
 	"unicode"
 	"unicode/utf8"
 
-	"gopkg.in/gcfg.v1/types"
+	"github.com/traetox/gcfg/types"
 	"gopkg.in/warnings.v0"
 )
 


### PR DESCRIPTION
@traetox 

The raw string support simply rewrites any backtick wrapped rvalue string as a double quoted string with padded escapes. That means things like:

```
`foo\dbar \t\s`
```

Get rewritten and handed back as:

```
"foo\\dbar \\t\\s"
```
