### PR TITLE
revert "always panic" behavior to throw errors instead. We had changed

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -15,7 +15,8 @@ func FatalOnly(err error) error {
 }
 
 func isFatal(err error) bool {
-	return true
+	_, ok := err.(extraData)
+	return !ok
 }
 
 type loc struct {


### PR DESCRIPTION
this previously to avoid "extra data" errors that don't cause ingesters
to exit, but those are easier to deal with than a panic.