### PR TITLE
adding some more context to errors when keys are bad

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -1,15 +1,16 @@
 package gcfg
 
-import warnings "gopkg.in/warnings.v0"
+import (
+	warnings "gopkg.in/warnings.v0"
+)
 
 // FatalOnly filters the results of a Read*Into invocation and returns only
 // fatal errors. That is, errors (warnings) indicating data for unknown
 // sections / variables is ignored. Example invocation:
 //
-//  err := gcfg.FatalOnly(gcfg.ReadFileInto(&cfg, configFile))
-//  if err != nil {
-//      ...
-//
+//	err := gcfg.FatalOnly(gcfg.ReadFileInto(&cfg, configFile))
+//	if err != nil {
+//	    ...
 func FatalOnly(err error) error {
 	return warnings.FatalOnly(err)
 }
@@ -27,6 +28,7 @@ type loc struct {
 
 type extraData struct {
 	loc
+	name string
 }
 
 type locErr struct {
@@ -46,7 +48,10 @@ func (l loc) String() string {
 }
 
 func (e extraData) Error() string {
-	return "can't store data at " + e.loc.String()
+	if e.name == `` {
+		return "can't store data at " + e.loc.String()
+	}
+	return "can't store data into key " + e.name + " at " + e.loc.String()
 }
 
 func (e locErr) Error() string {

--- a/errors.go
+++ b/errors.go
@@ -1,6 +1,8 @@
 package gcfg
 
 import (
+	"fmt"
+
 	warnings "gopkg.in/warnings.v0"
 )
 
@@ -51,7 +53,7 @@ func (e extraData) Error() string {
 	if e.name == `` {
 		return "can't store data at " + e.loc.String()
 	}
-	return "can't store data into key " + e.name + " at " + e.loc.String()
+	return fmt.Sprintf("can't store data into key %q at %s", e.name, e.loc.String())
 }
 
 func (e locErr) Error() string {

--- a/set.go
+++ b/set.go
@@ -278,7 +278,7 @@ func set(c *warnings.Collector, cfg interface{}, sect, sub, name string,
 	vSect, _ := fieldFold(vCfg, sect)
 	l := loc{section: sect}
 	if !vSect.IsValid() {
-		err := extraData{loc: l}
+		err := extraData{loc: l, name: name}
 		return c.Collect(err)
 	}
 	isSubsect := vSect.Kind() == reflect.Map
@@ -313,7 +313,7 @@ func set(c *warnings.Collector, cfg interface{}, sect, sub, name string,
 		panic(fmt.Errorf("field for section must be a map or a struct: "+
 			"section %q", sect))
 	} else if sub != "" {
-		return c.Collect(extraData{loc: l})
+		return c.Collect(extraData{loc: l, name: name})
 	}
 	// Empty name is a special value, meaning that only the
 	// section/subsection object is to be created, with no values set.
@@ -322,7 +322,7 @@ func set(c *warnings.Collector, cfg interface{}, sect, sub, name string,
 	}
 	vVar, t := idxFieldFold(vSect, name)
 	if !vVar.IsValid() {
-		return c.Collect(extraData{loc: l})
+		return c.Collect(extraData{loc: l, name: name})
 	}
 	// vVal is either single-valued var, or newly allocated value within multi-valued var
 	var vVal reflect.Value


### PR DESCRIPTION
Assuming you stuff in the key "Foobar" into a structure where it doesn't belong.

Instead of this error:
```
can't store data into section "Stream", subsection "stream1"
```

you get this error:
```
can't store data into key "Foobar" at section "Stream", subsection "stream1"
```
Closes issue https://github.com/gravwell/gcfg/issues/10