### PR TITLE
fix (#1006): Add option for arbitrary keys to pass through config parsing

### DIFF
--- a/read.go
+++ b/read.go
@@ -73,6 +73,7 @@ func readIntoPass(c *warnings.Collector, config interface{}, fset *token.FileSet
 		case token.EOL, token.COMMENT:
 			pos, tok, lit = s.Scan()
 		case token.LBRACK:
+			s.IdentMode("default")
 			pos, tok, lit = s.Scan()
 			if errs.Len() > 0 {
 				if err := c.Collect(errs.Err()); err != nil {
@@ -124,14 +125,21 @@ func readIntoPass(c *warnings.Collector, config interface{}, fset *token.FileSet
 			// If a section/subsection header was found, ensure a
 			// container object is created, even if there are no
 			// variables further down.
-
-			err := set(c, config, sect, sectsub, "", true, "", subsectPass)
+			t, err := set(c, config, sect, sectsub, "", true, "", subsectPass)
 			if err != nil {
 				err = errfn(err.Error())
+				if err = c.Collect(err); err != nil {
+					return err
+				}
 			}
-			err = c.Collect(err)
-			if err != nil {
-				return err
+			if t.identMode != "" {
+				err = s.IdentMode(t.identMode)
+				if err != nil {
+					err = errfn(err.Error())
+					if err = c.Collect(err); err != nil {
+						return err
+					}
+				}
 			}
 		case token.IDENT:
 			if sect == "" {
@@ -175,7 +183,7 @@ func readIntoPass(c *warnings.Collector, config interface{}, fset *token.FileSet
 					}
 				}
 			}
-			err := set(c, config, sect, sectsub, n, blank, v, subsectPass)
+			_, err := set(c, config, sect, sectsub, n, blank, v, subsectPass)
 			if err != nil {
 				return errfn(err.Error())
 			}

--- a/read_test.go
+++ b/read_test.go
@@ -98,6 +98,10 @@ type cNumS2 struct {
 }
 type cNumS3 struct{ FileMode os.FileMode }
 
+type cMap struct {
+	Section map[string]string `gcfg:",section=raw,ident=regex"`
+}
+
 type readtest struct {
 	gcfg string
 	exp  interface{}
@@ -203,6 +207,7 @@ var readtests = []struct {
 	{"\n[section]\nnonexistent=value", &cBasic{}, false},
 	// hyphen in name
 	{"[hyphen-in-section]\nhyphen-in-name=value", &cBasic{Hyphen_In_Section: cBasicS2{Hyphen_In_Name: "value"}}, true},
+	{"[hyphen-in-section]\nhyphen_in_name=value", &cBasic{}, false},
 	// ignore unexported fields
 	{"[unexported]\nname=value", &cBasic{}, false},
 	{"[exported]\nunexported=value", &cBasic{}, false},
@@ -269,6 +274,14 @@ var readtests = []struct {
 }}, {"type:textUnmarshaler", []readtest{
 	{"[section]\nname=value", &cTxUnm{Section: cTxUnmS1{Name: "value"}}, true},
 	{"[section]\nname=error", &cTxUnm{}, false},
+}}, {"type:rawMap", []readtest{
+	{"[section]\nname=value", &cMap{Section: map[string]string{"name": "value"}}, true},
+	{"[section]\nname-key=value", &cMap{Section: map[string]string{"name-key": "value"}}, true},
+	{"[section]\nname_key=value", &cMap{Section: map[string]string{"name_key": "value"}}, true},
+	{"[section]\nname-key=dash\nname_key=value", &cMap{Section: map[string]string{"name-key": "dash", "name_key": "value"}}, true},
+	{"[section]\n", &cMap{Section: map[string]string{}}, true},
+	{"[section]\nname-key=value\nname-key=wack", &cMap{}, false},
+	{"[section \"sub\"]\nname-key=value", &cMap{}, false},
 }},
 }
 
@@ -444,6 +457,12 @@ var panictests = []struct {
 }{
 	{"top", struct{}{}, "[section]\nname=value"},
 	{"section", &struct{ Section string }{}, "[section]\nname=value"},
+	{"rawsection", &struct {
+		Section string `gcfg:",section=raw"`
+	}{}, "[section]\nname=value"},
+	{"rawsectionmap", &struct {
+		Section map[string]int `gcfg:",section=raw"`
+	}{}, "[section]\nname=value"},
 	{"subsection", &struct{ Section map[string]string }{}, "[section \"subsection\"]\nname=value"},
 }
 

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -8,7 +8,6 @@
 //
 // Note that the API for the scanner package may change to accommodate new
 // features or implementation changes in gcfg.
-//
 package scanner
 
 import (
@@ -25,13 +24,11 @@ import (
 // encountered and a handler was installed, the handler is called with a
 // position and an error message. The position points to the beginning of
 // the offending token.
-//
 type ErrorHandler func(pos token.Position, msg string)
 
 // A Scanner holds the scanner's internal state while processing
 // a given text.  It can be allocated as part of another data
 // structure but must be initialized via Init before use.
-//
 type Scanner struct {
 	// immutable state
 	file *token.File  // source file handle
@@ -46,6 +43,7 @@ type Scanner struct {
 	rdOffset   int  // reading offset (position after current character)
 	lineOffset int  // current line offset
 	nextVal    bool // next token is expected to be a value
+	isLetter   func(rune) bool
 
 	// public state - ok to modify
 	ErrorCount int // number of errors encountered
@@ -53,7 +51,6 @@ type Scanner struct {
 
 // Read the next Unicode char into s.ch.
 // s.ch < 0 means end-of-file.
-//
 func (s *Scanner) next() {
 	if s.rdOffset < len(s.src) {
 		s.offset = s.rdOffset
@@ -86,7 +83,6 @@ func (s *Scanner) next() {
 
 // A mode value is a set of flags (or 0).
 // They control scanner behavior.
-//
 type Mode uint
 
 const (
@@ -107,7 +103,6 @@ const (
 //
 // Note that Init may call err if there is an error in the first character
 // of the file.
-//
 func (s *Scanner) Init(file *token.File, src []byte, err ErrorHandler, mode Mode) {
 	// Explicitly initialize all fields since a scanner may be reused.
 	if file.Size() != len(src) {
@@ -118,6 +113,7 @@ func (s *Scanner) Init(file *token.File, src []byte, err ErrorHandler, mode Mode
 	s.src = src
 	s.err = err
 	s.mode = mode
+	s.isLetter = isLetter
 
 	s.ch = ' '
 	s.offset = 0
@@ -146,6 +142,10 @@ func (s *Scanner) scanComment() string {
 	return string(s.src[offs:s.offset])
 }
 
+func isLetterWithRegex(ch rune) bool {
+	return ch == '_' || 'a' <= ch && ch <= 'z' || 'A' <= ch && ch <= 'Z' || ch >= 0x80 && unicode.IsLetter(ch)
+}
+
 func isLetter(ch rune) bool {
 	return 'a' <= ch && ch <= 'z' || 'A' <= ch && ch <= 'Z' || ch >= 0x80 && unicode.IsLetter(ch)
 }
@@ -156,7 +156,7 @@ func isDigit(ch rune) bool {
 
 func (s *Scanner) scanIdentifier() string {
 	offs := s.offset
-	for isLetter(s.ch) || isDigit(s.ch) || s.ch == '-' {
+	for s.isLetter(s.ch) || isDigit(s.ch) || s.ch == '-' {
 		s.next()
 	}
 	return string(s.src[offs:s.offset])
@@ -326,7 +326,6 @@ func (s *Scanner) skipWhitespace() {
 // Scan adds line information to the file added to the file
 // set with Init. Token positions are relative to that file
 // and thus relative to the file set.
-//
 func (s *Scanner) Scan() (pos token.Pos, tok token.Token, lit string) {
 scanAgain:
 	s.skipWhitespace()
@@ -340,7 +339,7 @@ scanAgain:
 		lit = s.scanValString()
 		tok = token.STRING
 		s.nextVal = false
-	case isLetter(ch):
+	case s.isLetter(ch):
 		lit = s.scanIdentifier()
 		tok = token.IDENT
 	default:
@@ -376,4 +375,16 @@ scanAgain:
 	}
 
 	return
+}
+
+func (s *Scanner) IdentMode(mode string) error {
+	switch mode {
+	case "default":
+		s.isLetter = isLetter
+	case "regex":
+		s.isLetter = isLetterWithRegex
+	default:
+		return fmt.Errorf("invalid ident (%s) provided", mode)
+	}
+	return nil
 }

--- a/set.go
+++ b/set.go
@@ -16,8 +16,10 @@ import (
 )
 
 type tag struct {
-	ident   string
-	intMode string
+	ident       string
+	intMode     string
+	sectionMode string
+	identMode   string
 }
 
 func newTag(ts string) tag {
@@ -27,6 +29,12 @@ func newTag(ts string) tag {
 	for _, tse := range s[1:] {
 		if strings.HasPrefix(tse, "int=") {
 			t.intMode = tse[len("int="):]
+		}
+		if strings.HasPrefix(tse, "section=") {
+			t.sectionMode = tse[len("section="):]
+		}
+		if strings.HasPrefix(tse, "ident=") {
+			t.identMode = tse[len("ident="):]
 		}
 	}
 	return t
@@ -268,22 +276,22 @@ func newValue(c *warnings.Collector, sect string, vCfg reflect.Value,
 }
 
 func set(c *warnings.Collector, cfg interface{}, sect, sub, name string,
-	blank bool, value string, subsectPass bool) error {
+	blank bool, value string, subsectPass bool) (tag, error) {
 	//
 	vPCfg := reflect.ValueOf(cfg)
 	if vPCfg.Kind() != reflect.Ptr || vPCfg.Elem().Kind() != reflect.Struct {
 		panic(fmt.Errorf("config must be a pointer to a struct"))
 	}
 	vCfg := vPCfg.Elem()
-	vSect, _ := fieldFold(vCfg, sect)
+	vSect, st := fieldFold(vCfg, sect)
 	l := loc{section: sect}
 	if !vSect.IsValid() {
 		err := extraData{loc: l, name: name}
-		return c.Collect(err)
+		return st, c.Collect(err)
 	}
-	isSubsect := vSect.Kind() == reflect.Map
+	isSubsect := vSect.Kind() == reflect.Map && st.sectionMode != "raw"
 	if subsectPass != isSubsect {
-		return nil
+		return st, nil
 	}
 	if isSubsect {
 		l.subsection = &sub
@@ -304,25 +312,46 @@ func set(c *warnings.Collector, cfg interface{}, sect, sub, name string,
 			var err error
 			pv, err = newValue(c, sect, vCfg, vType)
 			if err != nil {
-				return err
+				return st, err
 			}
 			vSect.SetMapIndex(k, pv)
 		}
 		vSect = pv.Elem()
-	} else if vSect.Kind() != reflect.Struct {
+	} else if vSect.Kind() != reflect.Struct && vSect.Kind() != reflect.Map {
 		panic(fmt.Errorf("field for section must be a map or a struct: "+
 			"section %q", sect))
 	} else if sub != "" {
-		return c.Collect(extraData{loc: l, name: name})
+		return st, c.Collect(extraData{loc: l, name: name})
+	} else if st.sectionMode == "raw" {
+		vst := vSect.Type()
+		if vst.Key().Kind() != reflect.String ||
+			vst.Elem().Kind() != reflect.String {
+			panic(fmt.Errorf("map for raw section must have string keys and "+
+				"string values: section %q", sect))
+		}
+		if vSect.IsNil() {
+			vSect.Set(reflect.MakeMap(vSect.Type()))
+		}
 	}
 	// Empty name is a special value, meaning that only the
 	// section/subsection object is to be created, with no values set.
 	if name == "" {
-		return nil
+		return st, nil
+	}
+	// sectionMode of raw is a special value to shortcut all folding of the name of the field.
+	if st.sectionMode == "raw" {
+		var err error
+		vv := vSect.MapIndex(reflect.ValueOf(name))
+		if !vv.IsValid() {
+			vSect.SetMapIndex(reflect.ValueOf(name), reflect.ValueOf(value))
+		} else {
+			err = locErr{msg: "duplicate key in raw section", loc: l}
+		}
+		return st, err
 	}
 	vVar, t := idxFieldFold(vSect, name)
 	if !vVar.IsValid() {
-		return c.Collect(extraData{loc: l, name: name})
+		return st, c.Collect(extraData{loc: l, name: name})
 	}
 	// vVal is either single-valued var, or newly allocated value within multi-valued var
 	var vVal reflect.Value
@@ -337,7 +366,7 @@ func set(c *warnings.Collector, cfg interface{}, sect, sub, name string,
 	}
 	if isMulti && blank {
 		vVar.Set(reflect.Zero(vVar.Type()))
-		return nil
+		return st, nil
 	}
 	if isMulti {
 		vVal = reflect.New(vVar.Type().Elem()).Elem()
@@ -365,12 +394,12 @@ func set(c *warnings.Collector, cfg interface{}, sect, sub, name string,
 			break
 		}
 		if err != errUnsupportedType {
-			return locErr{msg: err.Error(), loc: l}
+			return st, locErr{msg: err.Error(), loc: l}
 		}
 	}
 	if !ok {
 		// in case all setters returned errUnsupportedType
-		return locErr{msg: err.Error(), loc: l}
+		return st, locErr{msg: err.Error(), loc: l}
 	}
 	if isNew { // set reference if it was dereferenced and newly allocated
 		vVal.Set(vAddr)
@@ -378,5 +407,5 @@ func set(c *warnings.Collector, cfg interface{}, sect, sub, name string,
 	if isMulti { // append if multi-valued
 		vVar.Set(reflect.Append(vVar, vVal))
 	}
-	return nil
+	return st, nil
 }


### PR DESCRIPTION
<!-- 

The title of this PR should have the form:  [TYPE]([ISSUE_NUMBER]): [CHANGELOG_MESSAGE]

- If [TYPE] is fix or feat, the CHANGELOG_MESSAGE will be included in customer-facing, release change logs. 
- Other [TYPE]s WILL NOT be included in release change logs. 
- Check out https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type for other type ideas, or invent your own. 

-->

This PR is related to https://github.com/gravwell/gravwell/issues/1006

Make it possible to loosen the restriction on the gfcg side by section, in order to allow raw keys passed through ingesters without modification. Duplicates are prevented as they would be entirely hidden to any code outside the gcfg.

This allows the [attach config](https://github.com/gravwell/gravwell/blob/main/ingest/attach/attach.go#L32) just to be `type AttachConfig map[string]string` reducing the `Idxer` handling to make `Attachments()` simpler. Though this will require an update to every usage of AttachConfig to be 
```
Attach attach.AttachConfig `gcfg:",section=raw,ident=regex"
```

## Examples

The follow will read parts of a section into a map (while erroring on duplicates)
```go
type Config struct {
    Section map[string]string `gcfg:",section=raw"
} 
```
The following configs would be allowed
```
[section]
    key=value
    thing=other
    foo=bar
```
This would not be
```
[section]
    key=value
    key=another
```
However in a weird case this would be allowed
```
[section]
    key=""
    key=value
```
Not much we can do there in go without some wacky pointer stuff. 

Given the following struct
```go
type Config struct {
    Section map[string]string `gcfg:",section=raw,ident=regex"`
}
```
This would be allowed
```
[section]
    key-name=value
    key_name=value
```
