### PR TITLE
fix(scanner): correct backtick string escaping of backslash-quote sequences

### DIFF
--- a/issues_test.go
+++ b/issues_test.go
@@ -27,8 +27,8 @@ var testsGoogleCodeIssue1 = []struct {
 }
 
 // Value parse error should:
-//  - include plain type name
-//  - not include reflect internals
+//   - include plain type name
+//   - not include reflect internals
 func TestGoogleCodeIssue1(t *testing.T) {
 	for i, tt := range testsGoogleCodeIssue1 {
 		var c Config1
@@ -81,5 +81,70 @@ func TestIssue12(t *testing.T) {
 	}
 	if c.Section.Name != `"value"` {
 		t.Errorf("fail: want `\"value\"`, got %q", c.Section.Name)
+	}
+}
+
+func TestBacktickValues(t *testing.T) {
+	tests := []struct {
+		name string
+		gcfg string
+		want string
+		ok   bool
+	}{
+		{
+			name: "plain value",
+			gcfg: "[section]\nname=`hello`",
+			want: "hello",
+			ok:   true,
+		},
+		{
+			name: "value containing double-quote",
+			gcfg: "[section]\nname=`say \"hello\"`",
+			want: `say "hello"`,
+			ok:   true,
+		},
+		{
+			name: "value containing backslash",
+			gcfg: "[section]\nname=`C:\\path`",
+			want: `C:\path`,
+			ok:   true,
+		},
+		{
+			name: "value containing backslash immediately followed by double-quote",
+			gcfg: "[section]\nname=`C:\\\"path`",
+			want: `C:\"path`,
+			ok:   true,
+		},
+		{
+			name: "value containing multiple backslash-quote sequences",
+			gcfg: "[section]\nname=`\\\"foo\\\"bar`",
+			want: `\"foo\"bar`,
+			ok:   true,
+		},
+		{
+			name: "unterminated backtick",
+			gcfg: "[section]\nname=`unterminated",
+			ok:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var c cBasic
+			err := ReadStringInto(&c, tt.gcfg)
+
+			if tt.ok {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if c.Section.Name != tt.want {
+					t.Fatalf("got %q, want %q", c.Section.Name, tt.want)
+				}
+			} else {
+				if err == nil {
+					t.Fatalf("expected error, got nil (value=%q)", c.Section.Name)
+				}
+			}
+		})
 	}
 }

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -8,7 +8,6 @@
 //
 // Note that the API for the scanner package may change to accommodate new
 // features or implementation changes in gcfg.
-//
 package scanner
 
 import (
@@ -25,13 +24,11 @@ import (
 // encountered and a handler was installed, the handler is called with a
 // position and an error message. The position points to the beginning of
 // the offending token.
-//
 type ErrorHandler func(pos token.Position, msg string)
 
 // A Scanner holds the scanner's internal state while processing
 // a given text.  It can be allocated as part of another data
 // structure but must be initialized via Init before use.
-//
 type Scanner struct {
 	// immutable state
 	file *token.File  // source file handle
@@ -53,7 +50,6 @@ type Scanner struct {
 
 // Read the next Unicode char into s.ch.
 // s.ch < 0 means end-of-file.
-//
 func (s *Scanner) next() {
 	if s.rdOffset < len(s.src) {
 		s.offset = s.rdOffset
@@ -86,7 +82,6 @@ func (s *Scanner) next() {
 
 // A mode value is a set of flags (or 0).
 // They control scanner behavior.
-//
 type Mode uint
 
 const (
@@ -107,7 +102,6 @@ const (
 //
 // Note that Init may call err if there is an error in the first character
 // of the file.
-//
 func (s *Scanner) Init(file *token.File, src []byte, err ErrorHandler, mode Mode) {
 	// Explicitly initialize all fields since a scanner may be reused.
 	if file.Size() != len(src) {
@@ -231,20 +225,15 @@ func (s *Scanner) scanValString() string {
 
 		s.next()
 		ch := s.ch
-		var escapeState bool
+
 		for ch != '`' {
 			if ch < 0 {
 				s.error(offs, "raw string not terminated")
 				return ""
 			}
 
-			if ch == '\\' {
-				escapeState = true
+			if ch == '\\' || ch == '"' {
 				b.WriteRune('\\')
-			} else if ch == '"' && !escapeState {
-				b.WriteRune('\\')
-			} else {
-				escapeState = false
 			}
 
 			b.WriteRune(ch)
@@ -252,6 +241,7 @@ func (s *Scanner) scanValString() string {
 			s.next()
 			ch = s.ch
 		}
+
 		b.WriteRune('"')
 		s.next()
 		return b.String()
@@ -326,7 +316,6 @@ func (s *Scanner) skipWhitespace() {
 // Scan adds line information to the file added to the file
 // set with Init. Token positions are relative to that file
 // and thus relative to the file set.
-//
 func (s *Scanner) Scan() (pos token.Pos, tok token.Token, lit string) {
 scanAgain:
 	s.skipWhitespace()

--- a/scanner/scanner_test.go
+++ b/scanner/scanner_test.go
@@ -274,8 +274,9 @@ func TestScanValStringBacktickWonkyQuotesDoubleEscaped(t *testing.T) {
 	s.Init(f, []byte(src), nil, 0)
 	s.Scan()              // =
 	_, _, lit := s.Scan() // value
-	if lit != `"v\"a\"\\"lue"` {
-		t.Errorf("bad literal: got %s, expected %s", lit, `"v\"a\"\\"lue"`)
+	expected := `"v\"a\"\\\"lue"`
+	if lit != expected {
+		t.Errorf("bad literal: got %s, expected %s", lit, expected)
 	}
 	if s.ErrorCount > 0 {
 		t.Error("scanning error")
@@ -472,5 +473,75 @@ func BenchmarkScan(b *testing.B) {
 				break
 			}
 		}
+	}
+}
+
+func TestScanValStringBacktickEscaping(t *testing.T) {
+	tests := []struct {
+		name     string
+		src      string
+		expected string
+		ok       bool
+	}{
+		{
+			name:     "plain value",
+			src:      "= `hello`",
+			expected: `"hello"`,
+			ok:       true,
+		},
+		{
+			name:     "value containing double-quote",
+			src:      "= `say \"hello\"`",
+			expected: `"say \"hello\""`,
+			ok:       true,
+		},
+		{
+			name:     "value containing backslash",
+			src:      "= `C:\\path`",
+			expected: `"C:\\path"`,
+			ok:       true,
+		},
+		{
+			name:     "value containing backslash immediately followed by double-quote",
+			src:      "= `C:\\\"path`",
+			expected: `"C:\\\"path"`,
+			ok:       true,
+		},
+		{
+			name:     "value containing multiple backslash-quote sequences",
+			src:      "= `\\\"foo\\\"bar`",
+			expected: `"\\\"foo\\\"bar"`,
+			ok:       true,
+		},
+		{
+			name: "unterminated backtick",
+			src:  "= `unterminated",
+			ok:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var s Scanner
+
+			f := fset.AddFile("src", fset.Base(), len(tt.src))
+
+			s.Init(f, []byte(tt.src), nil, 0)
+			s.Scan() // =
+			_, _, lit := s.Scan()
+
+			if tt.ok {
+				if s.ErrorCount > 0 {
+					t.Fatalf("unexpected scan error")
+				}
+				if lit != tt.expected {
+					t.Fatalf("got %q, want %q", lit, tt.expected)
+				}
+			} else {
+				if s.ErrorCount == 0 {
+					t.Fatalf("expected scan error, got literal %q", lit)
+				}
+			}
+		})
 	}
 }


### PR DESCRIPTION
<!-- 

The title of this PR should have the form:  [TYPE]([ISSUE_NUMBER]): [CHANGELOG_MESSAGE]

- If [TYPE] is fix or feat, the CHANGELOG_MESSAGE will be included in customer-facing, release change logs. 
- Other [TYPE]s WILL NOT be included in release change logs. 
- Check out https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type for other type ideas, or invent your own. 

-->

This PR addresses [gravwell/gravwell#2279](https://github.com/gravwell/gravwell/issues/2279)

## This PR proposes...

- updating the escape logic for backtick strings that have backslash-quote sequences in them

## PR Tasks

<!-- Add tasks to this list as needed -->

- [x] e2e and/or unit tests included. If not, please provide an explanation.
- [ ] **Bug fixes only:** minimal repro steps included on the issue (for PR QA + Release QA).

## Reviewer Tasks

<!-- Add tasks to this list as needed -->

- [ ] e2e or unit tests are present to test the proposed changes.
- [ ] Code is sufficiently documented.
- [ ] Code meets quality and correctness expectations.
