### PR TITLE
fix(14): only collect error messages on first pass

### DIFF
--- a/set.go
+++ b/set.go
@@ -294,6 +294,10 @@ func set(c *warnings.Collector, cfg interface{}, sect, sub, name string,
 	vSect, st := fieldFold(vCfg, sect)
 	l := loc{section: sect}
 	if !vSect.IsValid() {
+		// only collect errors during the first passthrough
+		if subsectPass {
+			return nil
+		}
 		err := extraData{loc: l, name: name}
 		return st, c.Collect(err)
 	}

--- a/set.go
+++ b/set.go
@@ -52,7 +52,7 @@ func fieldFold(v reflect.Value, name string) (reflect.Value, tag) {
 	if unicode.IsLetter(r0) && !unicode.IsLower(r0) && !unicode.IsUpper(r0) {
 		n = "X"
 	}
-	n += strings.Replace(name, "-", "_", -1)
+	n += strings.ReplaceAll(name, "-", "_")
 	f, ok := v.Type().FieldByNameFunc(func(fieldName string) bool {
 		if !v.FieldByName(fieldName).CanSet() {
 			return false
@@ -231,7 +231,7 @@ func idxFieldFold(v reflect.Value, name string) (reflect.Value, tag, error) {
 	}
 	if f.Type().Kind() != reflect.Map ||
 		f.Type().Key() != reflect.TypeOf(Idx{}) ||
-		f.Type().Elem().Kind() != reflect.Ptr {
+		f.Type().Elem().Kind() != reflect.Pointer {
 		return reflect.Value{}, tag{}, ErrUservarStructShouldHaveSingleMapField
 	}
 	if f.IsNil() {
@@ -250,7 +250,7 @@ func idxFieldFold(v reflect.Value, name string) (reflect.Value, tag, error) {
 			idx = idxer.Idx(name)
 		}
 	default:
-		return reflect.Value{}, tag{}, fmt.Errorf("Unknown type on idxFieldFold: %T", idxer)
+		return reflect.Value{}, tag{}, fmt.Errorf("unknown type on idxFieldFold: %T", idxer)
 	}
 	vv := f.MapIndex(reflect.ValueOf(idx))
 	if !vv.IsValid() {
@@ -287,7 +287,7 @@ func set(c *warnings.Collector, cfg interface{}, sect, sub, name string,
 	blank bool, value string, subsectPass bool) (tag, error) {
 	//
 	vPCfg := reflect.ValueOf(cfg)
-	if vPCfg.Kind() != reflect.Ptr || vPCfg.Elem().Kind() != reflect.Struct {
+	if vPCfg.Kind() != reflect.Pointer || vPCfg.Elem().Kind() != reflect.Struct {
 		return tag{}, fmt.Errorf("config must be a pointer to a struct")
 	}
 	vCfg := vPCfg.Elem()
@@ -296,7 +296,7 @@ func set(c *warnings.Collector, cfg interface{}, sect, sub, name string,
 	if !vSect.IsValid() {
 		// only collect errors during the first passthrough
 		if subsectPass {
-			return nil
+			return tag{}, nil
 		}
 		err := extraData{loc: l, name: name}
 		return st, c.Collect(err)
@@ -309,7 +309,7 @@ func set(c *warnings.Collector, cfg interface{}, sect, sub, name string,
 		l.subsection = &sub
 		vst := vSect.Type()
 		if vst.Key().Kind() != reflect.String ||
-			vst.Elem().Kind() != reflect.Ptr ||
+			vst.Elem().Kind() != reflect.Pointer ||
 			vst.Elem().Elem().Kind() != reflect.Struct {
 			return st, fmt.Errorf("map field for section must have string keys and "+
 				" pointer-to-struct values: section %q", sect)
@@ -372,8 +372,8 @@ func set(c *warnings.Collector, cfg interface{}, sect, sub, name string,
 	var vVal reflect.Value
 	// multi-value if unnamed slice type
 	isMulti := vVar.Type().Name() == "" && vVar.Kind() == reflect.Slice ||
-		vVar.Type().Name() == "" && vVar.Kind() == reflect.Ptr && vVar.Type().Elem().Name() == "" && vVar.Type().Elem().Kind() == reflect.Slice
-	if isMulti && vVar.Kind() == reflect.Ptr {
+		vVar.Type().Name() == "" && vVar.Kind() == reflect.Pointer && vVar.Type().Elem().Name() == "" && vVar.Type().Elem().Kind() == reflect.Slice
+	if isMulti && vVar.Kind() == reflect.Pointer {
 		if vVar.IsNil() {
 			vVar.Set(reflect.New(vVar.Type().Elem()))
 		}
@@ -388,7 +388,7 @@ func set(c *warnings.Collector, cfg interface{}, sect, sub, name string,
 	} else {
 		vVal = vVar
 	}
-	isDeref := vVal.Type().Name() == "" && vVal.Type().Kind() == reflect.Ptr
+	isDeref := vVal.Type().Name() == "" && vVal.Type().Kind() == reflect.Pointer
 	isNew := isDeref && vVal.IsNil()
 	// vAddr is address of value to set (dereferenced & allocated as needed)
 	var vAddr reflect.Value

--- a/set_test.go
+++ b/set_test.go
@@ -1,0 +1,52 @@
+package gcfg
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestMisspelledSecionNameDoesNotProduceDuplicateErrorMessages(t *testing.T) {
+	var cfg struct {
+		Profile map[string]*struct {
+			Color string
+		}
+	}
+
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{
+			name: "misspelled subsection style section",
+			input: `
+[profileX "A"]
+color = white`,
+		},
+		{
+			name: "misspelled struct style section",
+			input: `
+[profileX]
+color = white`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ReadStringInto(&cfg, tt.input)
+			if err == nil {
+				t.Fatal("expected error for unknown section name, got nil")
+			}
+			errStr := err.Error()
+
+			// Each distinct error message should only appear once.
+			if n := strings.Count(errStr, `can't store data at section "profileX"`); n != 1 {
+				t.Errorf(`"can't store data at section" appeared %d time(s), want 1 — duplicate errors indicate issue
+ #14 regression:\n%s`, n, errStr)
+			}
+			if n := strings.Count(errStr, `can't store data into key "color" at section "profileX"`); n != 1 {
+				t.Errorf(`"can't store data into key" appeared %d time(s), want 1 — duplicate errors indicate issue #14
+ regression:\n%s`, n, errStr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- 

The title of this PR should have the form:  [TYPE]([ISSUE_NUMBER]): [CHANGELOG_MESSAGE]

- If [TYPE] is fix or feat, the CHANGELOG_MESSAGE will be included in customer-facing, release change logs. 
- Other [TYPE]s WILL NOT be included in release change logs. 
- Check out https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type for other type ideas, or invent your own. 

-->

This PR addresses https://github.com/gravwell/gcfg/issues/14

## This PR proposes...

- updating the error collecting logic to only collect errors on the first passthrough
- minor deprecation refactors related to `reflect.Ptr`

## PR Tasks

<!-- Add tasks to this list as needed -->

- [ ] e2e and/or unit tests included. If not, please provide an explanation.
- [ ] **Bug fixes only:** minimal repro steps included on the issue (for PR QA + Release QA).

## Reviewer Tasks

<!-- Add tasks to this list as needed -->

- [ ] e2e or unit tests are present to test the proposed changes.
- [ ] Code is sufficiently documented.
- [ ] Code meets quality and correctness expectations.
